### PR TITLE
Risk ! | exposed api keys! .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+# Just a heads up that all you API keys are publicly exposed. Since in app.py you use os.getenc I assume these are actually prudction API keys in which case please hide them ASAP.
+
 OPENAI_API_KEY = "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"
 PINECONE_API_KEY = "pcsk_wZ8gg_Pniivd3f6sgCmdXU8nL2AaRnfdnEQGnyJuJLAZVCNuRHTdBjfRcfvSVD6YE2FkH"
 LLAMA_API_KEY="f0481ae7-8dc0-4ecc-8771-85c37facdfd4"


### PR DESCRIPTION
I just left a comment that i noticed that all you API keys seem to be exposed in the .env file.